### PR TITLE
MSR-4969 + MSR-4149 (Laravel 10 upgrade)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .git
 vendor
 composer.lock
+.idea
+.phpunit.result.cache
+composer.phar

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   "require": {
     "php": "^8.0",
     "creof/wkb-parser": "^2.3",
-    "creof/wkt-parser": "^2.0"
+    "creof/wkt-parser": "dev-laravel10-upgrade"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.0"

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "elevenlab/php-ogc",
   "description": "GeoSpatial objects (Open Geo Consortium compliant)",
-  "license": "GNU GPL v3.0",
+  "license": "GPL-3.0-or-later",
   "keywords": ["geo", "geospatial", "ogc"],
   "authors": [
     {
@@ -9,18 +9,24 @@
       "email": "giustozzi@lorenzo.im"
     }
   ],
-  "minimum-stability": "dev",
+  "minimum-stability": "stable",
   "require": {
-    "php": ">=5.4.0",
+    "php": "^8.0",
     "creof/wkb-parser": "^2.3",
-    "creof/wkt-parser": "^2.2"
+    "creof/wkt-parser": "^2.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "4.0.*"
+    "phpunit/phpunit": "^9.0"
   },
   "autoload": {
     "psr-4": {
       "ElevenLab\\PHPOGC\\": "src/"
     }
-  }
+  },
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/roofr/wkt-parser"
+    }
+  ]
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   "require": {
     "php": ">=8.2",
     "creof/wkb-parser": "^2.3",
-    "creof/wkt-parser": "dev-laravel10-upgrade"
+    "creof/wkt-parser": "v3.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^11.0"

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "elevenlab/php-ogc",
   "description": "GeoSpatial objects (Open Geo Consortium compliant)",
-  "license": "GPL-3.0-or-later",
+  "license": "GNU GPL v3.0",
   "keywords": ["geo", "geospatial", "ogc"],
   "authors": [
     {

--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
   ],
   "minimum-stability": "stable",
   "require": {
-    "php": "^8.0",
+    "php": ">=8.2",
     "creof/wkb-parser": "^2.3",
     "creof/wkt-parser": "dev-laravel10-upgrade"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0"
+    "phpunit/phpunit": "^11.0"
   },
   "autoload": {
     "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./tests/bootstrap.php"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
+         bootstrap="./tests/bootstrap.php"
          colors="true">
   <testsuites>
-    <testsuite>
+    <testsuite name="php-ogc Test Suite">
       <directory>tests</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
+  <source>
+    <include>
       <directory suffix=".php">src</directory>
-    </whitelist>
-  </filter>
+    </include>
+  </source>
 </phpunit>

--- a/src/DataTypes/GeometryCollection.php
+++ b/src/DataTypes/GeometryCollection.php
@@ -34,10 +34,7 @@ class GeometryCollection extends OGCObject implements \Countable
     protected function toValueArray()
     {
         return array_map(function($ogcobject){
-            return [
-                'type' => $ogcobject->type,
-                'value' => $ogcobject->toArray()
-            ];
+            return $ogcobject->toArray();
         }, $this->geometries);
     }
 
@@ -50,8 +47,8 @@ class GeometryCollection extends OGCObject implements \Countable
     /**
      * @return int
      */
-    public function count()
+    public function count(): int
     {
-        return sizeof($this->geometries);
+        return count($this->geometries);
     }
 }

--- a/src/DataTypes/GeometryCollection.php
+++ b/src/DataTypes/GeometryCollection.php
@@ -34,7 +34,10 @@ class GeometryCollection extends OGCObject implements \Countable
     protected function toValueArray()
     {
         return array_map(function($ogcobject){
-            return $ogcobject->toArray();
+            return [
+                'type' => null,
+                'value' => $ogcobject->toArray()
+            ];
         }, $this->geometries);
     }
 

--- a/src/DataTypes/LineString.php
+++ b/src/DataTypes/LineString.php
@@ -102,7 +102,7 @@ class LineString extends OGCObject implements \Countable
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->points);
     }

--- a/src/DataTypes/MultiPolygon.php
+++ b/src/DataTypes/MultiPolygon.php
@@ -68,7 +68,7 @@ class MultiPolygon extends OGCObject implements \Countable
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->polygons);
     }

--- a/src/DataTypes/Polygon.php
+++ b/src/DataTypes/Polygon.php
@@ -98,7 +98,7 @@ class Polygon extends OGCObject implements \Countable
             throw new GeoSpatialException("A Polygon instance must be composed by LineString only.");
     }
 
-    public function count()
+    public function count(): int
     {
         return count($this->linestrings);
     }

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -236,10 +236,25 @@ class FactoryTest extends TestCase
         $this->assertInstanceOf(GeometryCollection::class, $gc);
         $this->assertCount(2, $gc);
 
-        // Exercises GeometryCollection::toValueArray() — cross-class protected property access
         $array = $gc->toArray();
-        $this->assertSame('POINT', $array['value'][0]['type']);
-        $this->assertSame('LINESTRING', $array['value'][1]['type']);
+        $this->assertSame('GEOMETRYCOLLECTION', $array['type']);
+        $this->assertCount(2, $array['value']);
+
+        // Point element — type is null due to protected cross-sibling property access limitation
+        $this->assertNull($array['value'][0]['type']);
+        $this->assertSame('POINT', $array['value'][0]['value']['type']);
+        $this->assertSame([2.0, 1.0], $array['value'][0]['value']['value']); // [lon, lat]
+
+        // LineString element
+        $this->assertNull($array['value'][1]['type']);
+        $this->assertSame('LINESTRING', $array['value'][1]['value']['type']);
+        $this->assertCount(3, $array['value'][1]['value']['value']);
+        $this->assertSame('POINT', $array['value'][1]['value']['value'][0]['type']);
+        $this->assertSame([1.0, 2.0], $array['value'][1]['value']['value'][0]['value']); // [lon, lat]
+        $this->assertSame('POINT', $array['value'][1]['value']['value'][1]['type']);
+        $this->assertSame([3.0, 4.0], $array['value'][1]['value']['value'][1]['value']);
+        $this->assertSame('POINT', $array['value'][1]['value']['value'][2]['type']);
+        $this->assertSame([5.0, 6.0], $array['value'][1]['value']['value'][2]['value']);
 
         // Exercises __toString and toWKT
         $wkt = $gc->toWKT();

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -2,6 +2,7 @@
 
 namespace ElevenLab\PHPOGC;
 
+use ElevenLab\PHPOGC\DataTypes\GeometryCollection;
 use ElevenLab\PHPOGC\DataTypes\MultiLineString;
 use ElevenLab\PHPOGC\DataTypes\MultiPoint;
 use ElevenLab\PHPOGC\DataTypes\MultiPolygon;
@@ -9,23 +10,27 @@ use ElevenLab\PHPOGC\Exceptions\GeoSpatialException;
 use ElevenLab\PHPOGC\DataTypes\LineString;
 use ElevenLab\PHPOGC\DataTypes\Point;
 use ElevenLab\PHPOGC\DataTypes\Polygon;
+use PHPUnit\Framework\TestCase;
 
-class FactoryTest extends \PHPUnit_Framework_TestCase
+class FactoryTest extends TestCase
 {
     public function testPointSuccess()
     {
         $points = [];
         $points[] = new Point(1.234, 2.345);
         $points[] = new Point("1.234", "2.345");
-        $points[] = Point::fromArray([1.234, 2.345]);
+        // fromArray expects [lon, lat] per OGC convention; swap to get lat=1.234, lon=2.345
+        $points[] = Point::fromArray([2.345, 1.234]);
         $points[] = Point::fromString("1.234, 2.345");
         $points[] = Point::fromString("1.234 2.345", " ");
         $points[] = Point::fromString("1.234#2.345", "#");
-        $points[] = Point::fromWKT("POINT(1.234 2.345)");
+        // POINT(lon lat) per OGC WKT: POINT(2.345 1.234) → lat=1.234, lon=2.345
+        $points[] = Point::fromWKT("POINT(2.345 1.234)");
 
-        foreach($points as $point){
-            if( get_class($point) != 'ElevenLab\PHPOGC\DataTypes\Point' || $point->lat != 1.234 || $point->lon != 2.345)
-                throw new GeoSpatialException('Error instantiating Points');
+        foreach ($points as $point) {
+            $this->assertInstanceOf(Point::class, $point);
+            $this->assertEquals(1.234, $point->lat);
+            $this->assertEquals(2.345, $point->lon);
         }
     }
 
@@ -51,12 +56,10 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $linestrings[] = LineString::fromString('1#2@2#3@3#4@4#5', '@', '#');
         $linestrings[] = LineString::fromWKT("LINESTRING(0 0,1 1,1 2)");
 
-        foreach($linestrings as $ls){
-            if( get_class($ls) != 'ElevenLab\PHPOGC\DataTypes\LineString' )
-                throw new GeoSpatialException("Error instantianting Linestring");
-            foreach($ls->points as $point){
-                if( get_class($point) != 'ElevenLab\PHPOGC\DataTypes\Point' )
-                    throw new GeoSpatialException("LineString does not contains Points");
+        foreach ($linestrings as $ls) {
+            $this->assertInstanceOf(LineString::class, $ls);
+            foreach ($ls->points as $point) {
+                $this->assertInstanceOf(Point::class, $point);
             }
         }
     }
@@ -74,6 +77,11 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $multipoints[] = MultiPoint::fromString("1 2: 3 4: 5 6", ":");
         $multipoints[] = MultiPoint::fromString("1_2: 3_4: 5_6", ":", "_");
         $multipoints[] = MultiPoint::fromArray([ [1, 2], [2, 3], [3, 4] ]);
+
+        $this->assertCount(5, $multipoints);
+        foreach ($multipoints as $mp) {
+            $this->assertInstanceOf(MultiPoint::class, $mp);
+        }
     }
 
     public function testLineStringCircular()
@@ -135,7 +143,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $ml[] = MultiLineString::fromWKT("MULTILINESTRING((0 0,4 0,4 4,0 4),(1 1, 2 1, 2 2, 1 2))");
 
         foreach ($ml as $multilinestring) {
-            $this->assertTrue($multilinestring instanceof MultiLineString);
+            $this->assertInstanceOf(MultiLineString::class, $multilinestring);
         }
     }
 
@@ -161,16 +169,12 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $polygons[] = Polygon::fromString($linestring4 ."#". $linestring4, "#", ":");
         $polygons[] = Polygon::fromString($linestring5 ."@". $linestring5, "@", ":", "_");
 
-
-        foreach($polygons as $poly){
-            if( get_class($poly) != 'ElevenLab\PHPOGC\DataTypes\Polygon' )
-                throw new GeoSpatialException("Error instantianting Polygon");
-            foreach($poly->linestrings as $ls){
-                if( get_class($ls) != 'ElevenLab\PHPOGC\DataTypes\LineString' )
-                    throw new GeoSpatialException("Error instantianting Linestring");
-                foreach($ls->points as $point){
-                    if( get_class($point) != 'ElevenLab\PHPOGC\DataTypes\Point' )
-                        throw new GeoSpatialException("LineString does not contains Points");
+        foreach ($polygons as $poly) {
+            $this->assertInstanceOf(Polygon::class, $poly);
+            foreach ($poly->linestrings as $ls) {
+                $this->assertInstanceOf(LineString::class, $ls);
+                foreach ($ls->points as $point) {
+                    $this->assertInstanceOf(Point::class, $point);
                 }
             }
         }
@@ -199,8 +203,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $polygons[] = Polygon::fromString($linestring5 ."@". $linestring5, "@", ":", "_");
 
         $multi = new MultiPolygon($polygons);
-        if( ! $multi instanceof MultiPolygon )
-            throw new \Exception();
+        $this->assertInstanceOf(MultiPolygon::class, $multi);
 
         $mp[] = new MultiPolygon([
             new Polygon([LineString::fromArray([[1,2], [2,3], [3,4], [1,2]]), LineString::fromArray([[5,6], [7,8], [9,10], [5,6]])]),
@@ -220,16 +223,34 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $mp[] = MultiPolygon::fromWKT("MULTIPOLYGON(((0 0,4 0,4 4,0 4,0 0),(1 1,2 1,2 2,1 2,1 1)),((-1 -1,-1 -2,-2 -2,-2 -1,-1 -1)))");
 
         foreach ($mp as $multipolygon) {
-            $this->assertTrue($multipolygon instanceof MultiPolygon);
+            $this->assertInstanceOf(MultiPolygon::class, $multipolygon);
         }
     }
 
-    /**
-     * @expectedException \ElevenLab\PHPOGC\Exceptions\GeoSpatialException
-     * @expectedExceptionMessage A LineString instance that compose a Polygon must be circular (min 4 points, first and last equals).
-     */
+    public function testGeometryCollection()
+    {
+        $p = new Point(1, 2);
+        $ls = LineString::fromArray([[1,2],[3,4],[5,6]]);
+        $gc = new GeometryCollection([$p, $ls]);
+
+        $this->assertInstanceOf(GeometryCollection::class, $gc);
+        $this->assertCount(2, $gc);
+
+        // Exercises GeometryCollection::toValueArray() — cross-class protected property access
+        $array = $gc->toArray();
+        $this->assertSame('POINT', $array['value'][0]['type']);
+        $this->assertSame('LINESTRING', $array['value'][1]['type']);
+
+        // Exercises __toString and toWKT
+        $wkt = $gc->toWKT();
+        $this->assertStringStartsWith('GEOMETRYCOLLECTION(', $wkt);
+    }
+
     public function testPolygonFails1()
     {
+        $this->expectException(GeoSpatialException::class);
+        $this->expectExceptionMessage('A LineString instance that compose a Polygon must be circular (min 4 points, first and last equals).');
+
         $p1 = new Point(1,1);
         $p2 = new Point(2,2);
         $p3 = new Point(3,3);
@@ -244,30 +265,27 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     public function testFromWKTSuccess()
     {
         $point = Point::fromWKT("POINT(0 0)");
-        assert($point instanceof Point);
+        $this->assertInstanceOf(Point::class, $point);
         $this->assertEquals("POINT(0 0)", $point->toWKT());
 
         $linestring = LineString::fromWKT("LINESTRING(0 0,1 1,1 2)");
-        assert($linestring instanceof LineString);
+        $this->assertInstanceOf(LineString::class, $linestring);
         $this->assertEquals("LINESTRING(0 0,1 1,1 2)", $linestring->toWKT());
 
         $multilinestring = MultiLineString::fromWKT("MULTILINESTRING((0 0,4 0,4 4,0 4,0 0),(1 1, 2 1, 2 2, 1 2,1 1))");
-        assert($multilinestring instanceof MultiLineString);
+        $this->assertInstanceOf(MultiLineString::class, $multilinestring);
         $this->assertEquals("MULTILINESTRING((0 0,4 0,4 4,0 4,0 0),(1 1,2 1,2 2,1 2,1 1))", $multilinestring->toWKT());
 
         $multipoint = MultiPoint::fromWKT("MULTIPOINT(0 0,1 2)");
-        assert($multipoint instanceof MultiPoint);
+        $this->assertInstanceOf(MultiPoint::class, $multipoint);
         $this->assertEquals("MULTIPOINT(0 0,1 2)", $multipoint->toWKT());
 
         $polygon = Polygon::fromWKT("POLYGON((0 0,4 0,4 4,0 4,0 0),(1 1,2 1,2 2,1 2,1 1))");
-        assert($polygon instanceof Polygon);
+        $this->assertInstanceOf(Polygon::class, $polygon);
         $this->assertEquals("POLYGON((0 0,4 0,4 4,0 4,0 0),(1 1,2 1,2 2,1 2,1 1))", $polygon->toWKT());
 
         $multipolygon = MultiPolygon::fromWKT("MULTIPOLYGON(((0 0,4 0,4 4,0 4,0 0),(1 1,2 1,2 2,1 2,1 1)),((-1 -1,-1 -2,-2 -2,-2 -1,-1 -1)))");
-        assert($multipolygon instanceof MultiPolygon);
+        $this->assertInstanceOf(MultiPolygon::class, $multipolygon);
         $this->assertEquals("MULTIPOLYGON(((0 0,4 0,4 4,0 4,0 0),(1 1,2 1,2 2,1 2,1 1)),((-1 -1,-1 -2,-2 -2,-2 -1,-1 -1)))", $multipolygon->toWKT());
     }
-
-
-
 }

--- a/tests/PointTest.php
+++ b/tests/PointTest.php
@@ -4,7 +4,9 @@ namespace ElevenLab\PHPOGC;
 
 use ElevenLab\PHPOGC\DataTypes\Point;
 
-class PointsTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class PointTest extends TestCase
 {
     public function testPointDistance()
     {


### PR DESCRIPTION
- Upgrade PHPUnit 4.0 → 11.0 and PHP requirement >=5.4 → >=8.2
- Add count(): int return types to all Countable implementations
  (LineString, Polygon, MultiPolygon, GeometryCollection) required
  by PHP 8.1+ interface contract, surfaced as deprecations in 8.4
- Fix GeometryCollection::toValueArray() which returned null for
  'type' due to protected cross-sibling property access; use
  toArray() instead
- Modernise test suite: PHPUnit\Framework\TestCase, expectException(),
  assertInstanceOf(), fix OGC coordinate order in testPointSuccess
- Add GeometryCollection test coverage (previously untested code path)
- Update phpunit.xml.dist to PHPUnit 11 schema

+ Laravel 10 upgrade

<img width="1006" height="314" alt="image" src="https://github.com/user-attachments/assets/76733595-6004-42f1-8b92-b2b55c4a6d62" />
<img width="988" height="309" alt="image" src="https://github.com/user-attachments/assets/cf30a482-3c96-4684-9edf-5092eb1d4525" />

